### PR TITLE
added BusKill hardware dead man switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ No affiliate codes or anything, just good deals I've found.
 | Hak5.org | N/A | 11/25 | N/A |
 | Maltronics.com | 10-25% | 11/20 | https://maltronics.com/collections/ |
 | hackin9.org | Up to 50% off | 11/26 | [link](https://hakin9.org/shop/) |
+| buskill.in | 10% off | 11/26 | [link](https://buskill.in/buy/) |
 
 ## Certifications
 


### PR DESCRIPTION
Please add the BusKill laptop kill cord discount to your "hardware" section

## BusKill is 10% off

#### The Deal

BusKill's black friday deal is 10% off all products purchased between Nov 19 to Dec 04 2022.

No code is needed. The total will be reduced by 10% at checkout for all orders paid with cryptocurrencies.

 * https://www.buskill.in/bitcoin-black-friday-2022/

#### What is BusKill? How is it InfoSec Related?

BusKill is an open-source hardware and software project that uses a hardware tripwire/dead-man-switch (a usb cable with a magnetic breakaway) to trigger your computer to lock or shutdown if the user is physically separated from their machine.

 * https://en.wikipedia.org/wiki/BusKill

The following guide describes how BusKill can be configured to wipe the LUKS Header (containing the FDE key) and its metadata. It shows a video demo where the machine wiped the keys & powered-off in <6 seconds, and it includes a post-execution forensic analysis in Kali with bulk_extractor

 * https://www.buskill.in/luks-self-destruct/